### PR TITLE
[D-0] Magpie 이미지 처리 기능 오류에 대한 수정

### DIFF
--- a/Projects/Magpie/Sources/Cache/DiskStorage.swift
+++ b/Projects/Magpie/Sources/Cache/DiskStorage.swift
@@ -16,5 +16,5 @@ final class DiskStorage<T>: Storage {
   }
 
   func setObject(_ object: T, forKey key: String) {}
-  func value(forKey key: String) -> T? { return nil }
+  func object(forKey key: String) -> T? { return nil }
 }

--- a/Projects/Magpie/Sources/Cache/ImageCache.swift
+++ b/Projects/Magpie/Sources/Cache/ImageCache.swift
@@ -34,11 +34,11 @@ final class ImageCache {
   }
 
   func retrieve(forKey key: String) -> UIImage? {
-    if let memoryImage = memoryStorage.value(forKey: key) {
+    if let memoryImage = memoryStorage.object(forKey: key) {
       return memoryImage
     }
 
-    if let diskImage = diskStorage.value(forKey: key) {
+    if let diskImage = diskStorage.object(forKey: key) {
       memoryStorage.setObject(diskImage, forKey: key)
       return diskImage
     }

--- a/Projects/Magpie/Sources/Cache/MemoryStorage.swift
+++ b/Projects/Magpie/Sources/Cache/MemoryStorage.swift
@@ -15,7 +15,7 @@ final class MemoryStorage<T: AnyObject>: Storage {
     storage.setObject(object, forKey: key as NSString)
   }
 
-  func value(forKey key: String) -> T? {
-    return storage.value(forKey: key) as? T
+  func object(forKey key: String) -> T? {
+    return storage.object(forKey: key as NSString)
   }
 }

--- a/Projects/Magpie/Sources/Cache/Storage.swift
+++ b/Projects/Magpie/Sources/Cache/Storage.swift
@@ -12,5 +12,5 @@ protocol Storage {
   associatedtype T
 
   func setObject(_ object: T, forKey key: String)
-  func value(forKey key: String) -> T?
+  func object(forKey key: String) -> T?
 }

--- a/Projects/Magpie/Sources/Magpie.swift
+++ b/Projects/Magpie/Sources/Magpie.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Omarket. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 public struct Magpie<Base> {
   public let base: Base
@@ -23,3 +23,7 @@ extension MagpieCompatible {
     get { Magpie(self) }
   }
 }
+
+// MARK: - Extension MagpieCompatible
+
+extension UIImageView: MagpieCompatible {}


### PR DESCRIPTION
close #25

### 배경

- 이슈: #25 

### 작업 내용

배경에 참조해둔 에러 이슈에 대해 수정을 했습니다.
1. 메인스레드에서 image를 UI 요소에 할당하도록 변경
2. NSCache의 value 메서드가 아닌 object 메서드를 사용하도록 변경
3. UIImageView가 MagpieCompatible를 채택하도록 변경
4. objc_getAssociatedObject / objc_setAssociatedObject 기능 추가 (Extension에서 저장 프로퍼티처럼 사용할 수 있습니다.)

### 테스트 방법

Magpie를 import한 후 UIImageView에 대해 mp 프로퍼티로 접근해서 사용할 수 있습니다.

### 리뷰 노트

Magpie를 통해 접근하도록 해야했고 extension에 저장 프로퍼티처럼 사용하기 위해 objc_getAssociatedObject / objc_setAssociatedObject을 사용했지만 아닌 경우 UIImageView를 Wrapped한 CustomImageView로 만들어서 사용할 수도 있을 것 같습니다. :)