### PR TITLE
[D-2] 메인 화면 Header 높이 및 상품 Cell 수정

### DIFF
--- a/Projects/OmarketApp/Resources/LaunchScreen.storyboard
+++ b/Projects/OmarketApp/Resources/LaunchScreen.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -26,7 +25,7 @@
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" red="0.98984760049999998" green="0.98984760049999998" blue="0.98984760049999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="ZLt-wp-q5i" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="bCm-Hl-UdS"/>
                             <constraint firstItem="ZLt-wp-q5i" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="f9e-3S-MEL"/>
@@ -40,8 +39,5 @@
     </scenes>
     <resources>
         <image name="Logo" width="252" height="252"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/Projects/OmarketApp/Sources/Application/Coordinator/AppCoordinator.swift
+++ b/Projects/OmarketApp/Sources/Application/Coordinator/AppCoordinator.swift
@@ -36,6 +36,7 @@ final class AppCoordinator: Coordinator {
     mainCoordinator.parentCoordinator = self
 
     mainNavigationController.tabBarItem = UITabBarItem(title: nil, image: ODS.Icon.home, tag: 0)
+    mainNavigationController.navigationBar.tintColor = .label
 
     tabBarController.viewControllers = [mainNavigationController]
     navigationController.viewControllers = [tabBarController]

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Main/View/MainEventCollectionViewCell.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Main/View/MainEventCollectionViewCell.swift
@@ -42,7 +42,7 @@ extension MainEventCollectionViewCell {
     contentView.addSubview(imageView)
 
     imageView.snp.makeConstraints {
-      $0.edges.equalToSuperview()
+      $0.directionalEdges.equalToSuperview()
     }
   }
 }

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Main/View/MainProductCollectionViewHeader.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Main/View/MainProductCollectionViewHeader.swift
@@ -18,7 +18,7 @@ final class MainProductCollectionViewHeader: UICollectionReusableView {
 
   private let titleLabel: UILabel = {
     let label = UILabel()
-    label.font = ODS.Font.H_B16
+    label.font = ODS.Font.H_B18
     label.text = "이런 제품은 어떤가요?"
 
     return label
@@ -26,10 +26,10 @@ final class MainProductCollectionViewHeader: UICollectionReusableView {
 
   private let showProductsButton: UIButton = {
     let button = UIButton()
-    button.titleLabel?.font = ODS.Font.B_R13
+    button.titleLabel?.font = ODS.Font.B_R15
     button.imageView?.contentMode = .scaleAspectFit
     button.semanticContentAttribute = .forceRightToLeft
-    button.imageEdgeInsets = .init(top: 4.0, left: 4.0, bottom: 4.0, right: 4.0)
+    button.imageEdgeInsets = .init(top: 4.0, left: 8.0, bottom: 4.0, right: 4.0)
 
     button.tintColor = .label
     button.setTitleColor(UIColor.label, for: .normal)

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Main/ViewController/MainViewController.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Main/ViewController/MainViewController.swift
@@ -17,7 +17,7 @@ import SnapKit
 final class MainViewController: UIViewController {
   private typealias MainDataSource = RxCollectionViewSectionedReloadDataSource<ProductSection>
 
-  private lazy var menuSegmentControl = ODSCategoryView(items: ["오픈마켓", "이벤트"])
+  private lazy var menuSegmentControl = ODSCategoryView(items: viewModel.categories)
   private lazy var collectionView: UICollectionView = {
     let layout = configureCompositionalLayout()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
@@ -60,8 +60,12 @@ final class MainViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     configureUI()
-    configureNavigationBar()
     bindUI()
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    configureNavigationBar()
   }
 
   private func bindUI() {
@@ -172,7 +176,7 @@ extension MainViewController {
 
     let headerSize = NSCollectionLayoutSize(
       widthDimension: .fractionalWidth(1.0),
-      heightDimension: .absolute(48.0)
+      heightDimension: .absolute(60.0)
     )
     let header = NSCollectionLayoutBoundarySupplementaryItem(
       layoutSize: headerSize,
@@ -190,7 +194,7 @@ extension MainViewController {
   }
 
   private func configureNavigationBar() {
-    title = viewModel.title
+    navigationItem.title = viewModel.title
     navigationController?.navigationBar.titleTextAttributes = [
       .foregroundColor: UIColor.white
     ]
@@ -211,8 +215,7 @@ extension MainViewController {
     }
 
     pageControl.snp.makeConstraints {
-      $0.centerY.equalToSuperview()
-      $0.centerX.equalToSuperview()
+      $0.center.equalToSuperview()
     }
   }
 }

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Main/ViewModel/MainViewModel.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Main/ViewModel/MainViewModel.swift
@@ -17,6 +17,7 @@ protocol MainViewModelInput {
 
 protocol MainViewModelOutput {
   var title: String { get }
+  var categories: [String] { get }
   var sections: Observable<[ProductSection]> { get }
 }
 
@@ -24,7 +25,8 @@ protocol MainViewModelable: MainViewModelInput, MainViewModelOutput {}
 
 final class MainViewModel: MainViewModelable {
   // Input
-  var title = "오픈 마켓"
+  let title = "오픈마켓"
+  let categories = ["오픈마켓", "신상품"]
   var sections: Observable<[ProductSection]> {
     return Observable.combineLatest(
       Observable.just(ProductEvent.items),

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/ProductCell/ProductCell.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/ProductCell/ProductCell.swift
@@ -19,8 +19,6 @@ final class ProductCell: UICollectionViewCell {
     let imageView = UIImageView()
     imageView.contentMode = .scaleAspectFill
     imageView.clipsToBounds = true
-    imageView.layer.cornerRadius = 20
-    
     return imageView
   }()
   
@@ -47,14 +45,14 @@ final class ProductCell: UICollectionViewCell {
   
   private let discountPercentLabel: UILabel = {
     let label = UILabel()
-    label.font = ODS.Font.B_R09
+    label.font = ODS.Font.B_R13
     label.textColor = .systemRed
     return label
   }()
   
   private let priceLabel: UILabel = {
     let label = UILabel()
-    label.font = ODS.Font.B_R09
+    label.font = ODS.Font.B_R13
     label.textColor = .systemGray
     
     return label
@@ -62,7 +60,7 @@ final class ProductCell: UICollectionViewCell {
   
   private let bargainPriceLabel: UILabel = {
     let label = UILabel()
-    label.font = ODS.Font.B_R09
+    label.font = ODS.Font.B_R15
     
     return label
   }()
@@ -70,21 +68,21 @@ final class ProductCell: UICollectionViewCell {
   private let stockStackView: UIStackView = {
     let stackView = UIStackView()
     stackView.axis = .vertical
-    stackView.alignment = .center
+    stackView.alignment = .trailing
     
     return stackView
   }()
   
   private let stockTitleLabel: UILabel = {
     let label = UILabel()
-    label.font = ODS.Font.B_R09
+    label.font = ODS.Font.B_R13
     
     return label
   }()
   
   private let stockLabel: UILabel = {
     let label = UILabel()
-    label.font = ODS.Font.B_R09
+    label.font = ODS.Font.B_R13
     
     return label
   }()
@@ -145,7 +143,7 @@ final class ProductCell: UICollectionViewCell {
   private func setupLayout() {
     productImageView.snp.makeConstraints {
       $0.top.leading.trailing.equalToSuperview()
-      $0.height.equalTo(productImageView.snp.width).multipliedBy(9/8)
+      $0.height.equalTo(productImageView.snp.width).multipliedBy(1.2)
     }
     
     productNameLabel.snp.makeConstraints {
@@ -169,6 +167,7 @@ final class ProductCell: UICollectionViewCell {
 private extension UILabel {
   func strike() {
     guard let text = self.text else { return }
+
     let attributedString = NSMutableAttributedString(string: text)
     attributedString.addAttribute(
       NSAttributedString.Key.strikethroughStyle,
@@ -180,9 +179,7 @@ private extension UILabel {
   
   func boldNumber() {
     guard let text = self.text,
-          let number = text.components(separatedBy: " ").first else {
-      return
-    }
+          let number = text.components(separatedBy: " ").first else { return }
     
     let boldFont = UIFont.boldSystemFont(ofSize: self.font.pointSize)
     

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/ProductsScene/ProductsView.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/ProductsScene/ProductsView.swift
@@ -24,8 +24,9 @@ final class ProductsView: UIView {
   }()
   
   private(set) lazy var productsCollectionView: UICollectionView = {
-    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeCollectionViewLayout())
-    
+    let layout = makeCollectionViewLayout()
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+
     return collectionView
   }()
   
@@ -53,12 +54,12 @@ final class ProductsView: UIView {
   
   private func setupLayout() {
     productsCollectionView.snp.makeConstraints {
-      $0.edges.equalTo(self.safeAreaLayoutGuide)
+      $0.edges.equalToSuperview()
     }
     
     addProductButton.snp.makeConstraints {
       $0.width.height.equalTo(50)
-      $0.trailing.bottom.equalTo(self.safeAreaLayoutGuide).inset(20)
+      $0.trailing.bottom.equalToSuperview().offset(-20.0)
     }
   }
   
@@ -69,26 +70,30 @@ final class ProductsView: UIView {
       forCellWithReuseIdentifier: ProductCell.identifier
     )
   }
-  
+
   private func makeCollectionViewLayout() -> UICollectionViewCompositionalLayout {
     return UICollectionViewCompositionalLayout { _, environment in
-      let itemWidth = environment.container.effectiveContentSize.width / 2
-      let itemHeight = itemWidth * 7 / 5
-    
+      let itemWidth = (environment.container.effectiveContentSize.width - 40.0) * 0.5
+      let itemHeight = itemWidth * 1.5
+
       let itemSize = NSCollectionLayoutSize(
         widthDimension: .absolute(itemWidth),
         heightDimension: .absolute(itemHeight)
       )
       let item = NSCollectionLayoutItem(layoutSize: itemSize)
-      item.contentInsets = NSDirectionalEdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8)
-      
+
       let groupSize = NSCollectionLayoutSize(
         widthDimension: .fractionalWidth(1.0),
         heightDimension: .absolute(itemHeight)
       )
       let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-      
-      return NSCollectionLayoutSection(group: group)
+      group.interItemSpacing = .fixed(8.0)
+
+      let section = NSCollectionLayoutSection(group: group)
+      section.interGroupSpacing = 48.0
+      section.contentInsets = .init(top: 8.0, leading: 16.0, bottom: 16.0, trailing: 16.0)
+
+      return section
     }
   }
 }

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/ProductsScene/ProductsViewController.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/ProductsScene/ProductsViewController.swift
@@ -28,22 +28,29 @@ class ProductsViewController: UIViewController {
   
   override func loadView() {
     super.loadView()
-    
     view = ProductsView()
   }
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    
     bind()
     viewModel.requestProducts(pageNumber: 1, itemsPerPage: 20)
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    configureNavigationBar()
+  }
+
+  private func configureNavigationBar() {
+    navigationItem.title = viewModel.title
+    navigationController?.navigationBar.topItem?.backBarButtonItem = UIBarButtonItem(title: nil)
+    navigationController?.navigationBar.titleTextAttributes = nil
   }
   
   private func bind() {
     guard let view = view as? ProductsView else { return }
-    
-    self.title = viewModel.title
-    
+
     view.addProductButton.rx.tap
       .bind { [weak self] in
         self?.viewModel.didTapAddProductButton()

--- a/Projects/OmarketApp/Sources/Utils/Extension/UIBarButtonItem+Extension.swift
+++ b/Projects/OmarketApp/Sources/Utils/Extension/UIBarButtonItem+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  UIBarButtonItem+Extension.swift
+//  OmarketApp
+//
+//  Created by Ringo on 2022/10/14.
+//  Copyright © 2022 Omarket. All rights reserved.
+//
+
+import UIKit
+
+extension UIBarButtonItem {
+  convenience init(title: String?) {
+    self.init(title: title, style: .plain, target: nil, action: nil)
+  }
+}

--- a/Projects/OmarketApp/Sources/Utils/Extension/UICollectionViewCell+Extension.swift
+++ b/Projects/OmarketApp/Sources/Utils/Extension/UICollectionViewCell+Extension.swift
@@ -1,5 +1,5 @@
 //
-//  UICollectionViewCell+.swift
+//  UICollectionViewCell+Extension.swift
 //  OmarketApp
 //
 //  Created by 김도연 on 2022/08/27.


### PR DESCRIPTION
### 배경

- 이슈: #41 

### 작업 내용
- 메인 화면의 상품 전체보기 헤더의 높이를 변경
- 상품의 CollectionView Cell의 디자인이 기존의 디자인 (Radius가 없는 디자인)을 준수하도록 변경했습니다.

### 리뷰노트
높이를 변경해준 이유는 전체보기를 탭하기 쉽도록 사용자 경험을 위해 변경했고 상품 Cell 디자인에서 Radius가 없는 각진 디자인이 기존의 디자인이었기에 변경했습니다. :)

### 스크린샷 및 영상

|수정된 화면|
|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/94151993/195682353-99001a8a-e081-437e-8031-18a8784b4df9.png"/>|
