### PR TITLE
[D-3] 상세 화면 DiscountPercent 계산 로직 에러 수정 및 더보기 버튼 추가

### DIFF
--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/Coordinator/DetailCoordinator.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/Coordinator/DetailCoordinator.swift
@@ -21,7 +21,7 @@ final class DetailCoordinator: Coordinator {
     let network = NetworkServiceImpl()
     let repository = ProductRepositoryImpl(networkService: network)
     let useCase = ProductFetchUseCaseImpl(repository: repository)
-    let viewModel = DetailViewModelImpl(useCase: useCase, productId: productId)
+    let viewModel = DetailViewModel(useCase: useCase, productId: productId)
     let viewController = DetailViewController(viewModel: viewModel)
     
     viewController.coordinator = self

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/View/DetailView.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/View/DetailView.swift
@@ -229,7 +229,7 @@ final class DetailView: UIView {
     stockLabel.text = content.stock
     priceLabel.text = content.price
     addStroke(label: priceLabel)
-    discountedPriceLabel.text = content.bargainPrice
+    discountedPriceLabel.text = content.discountPrice
     discountPercentageLabel.text = content.discountPercentage
   }
 }

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewController/DetailViewController.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewController/DetailViewController.swift
@@ -13,13 +13,13 @@ import SnapKit
 
 final class DetailViewController: UIViewController {
   
-  private let viewModel: DetailViewModel
+  private let viewModel: DetailViewModelable
   private let disposeBag = DisposeBag()
   weak var coordinator: DetailCoordinator?
   private let mainView = DetailView(frame: .zero)
   private let editBarButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis"))
   
-  init(viewModel: DetailViewModel) {
+  init(viewModel: DetailViewModelable) {
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
   }

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewController/DetailViewController.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewController/DetailViewController.swift
@@ -17,6 +17,7 @@ final class DetailViewController: UIViewController {
   private let disposeBag = DisposeBag()
   weak var coordinator: DetailCoordinator?
   private let mainView = DetailView(frame: .zero)
+  private let ellipsisButten = UIBarButtonItem(image: UIImage(systemName: "ellipsis"))
   
   init(viewModel: DetailViewModel) {
     self.viewModel = viewModel
@@ -41,7 +42,7 @@ extension DetailViewController {
     title = "상품상세"
     view.backgroundColor = .systemBackground
     view.addSubview(mainView)
-    
+    navigationItem.rightBarButtonItem = ellipsisButten
     mainView.snp.makeConstraints {
       $0.edges.equalTo(self.view.safeAreaLayoutGuide)
     }
@@ -52,6 +53,27 @@ extension DetailViewController {
 
 extension DetailViewController {
   private func bind() {
+    ellipsisButten.rx.tap
+      .bind { [weak self] in
+        let alert = UIAlertController(
+          title: nil,
+          message: nil,
+          preferredStyle: UIAlertController.Style.actionSheet
+        )
+        let editAction = UIAlertAction(title: "수정", style: .default) {_ in
+          // action
+        }
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) {_ in
+          // action
+        }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        [editAction, deleteAction, cancelAction].forEach {
+          alert.addAction($0)
+        }
+        self?.present(alert, animated: true)
+      }.disposed(by: disposeBag)
+    
     viewModel
       .productImageURL
       .observe(on: MainScheduler.instance)

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewController/DetailViewController.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewController/DetailViewController.swift
@@ -17,7 +17,7 @@ final class DetailViewController: UIViewController {
   private let disposeBag = DisposeBag()
   weak var coordinator: DetailCoordinator?
   private let mainView = DetailView(frame: .zero)
-  private let ellipsisButten = UIBarButtonItem(image: UIImage(systemName: "ellipsis"))
+  private let editBarButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis"))
   
   init(viewModel: DetailViewModel) {
     self.viewModel = viewModel
@@ -42,7 +42,7 @@ extension DetailViewController {
     title = "상품상세"
     view.backgroundColor = .systemBackground
     view.addSubview(mainView)
-    navigationItem.rightBarButtonItem = ellipsisButten
+    navigationItem.rightBarButtonItem = editBarButton
     mainView.snp.makeConstraints {
       $0.edges.equalTo(self.view.safeAreaLayoutGuide)
     }
@@ -53,7 +53,7 @@ extension DetailViewController {
 
 extension DetailViewController {
   private func bind() {
-    ellipsisButten.rx.tap
+    editBarButton.rx.tap
       .bind { [weak self] in
         let alert = UIAlertController(
           title: nil,

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewModel/DetailViewModelItem.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewModel/DetailViewModelItem.swift
@@ -15,7 +15,7 @@ struct DetailViewModelItem {
   let currency: String
   let price: String?
   let bargainPrice: String
-  let discountPercentage: String?
+  var discountPercentage: String?
   let stock: String
   
   init(product: Product, formatter: NumberFormatter? = nil) {
@@ -23,6 +23,8 @@ struct DetailViewModelItem {
     self.body = product.description
     self.thumbnail = product.thumbnail
     self.currency = product.currency == "KRW" ? "원" : "달러"
+    self.stock = "\(product.stock) 개"
+    self.bargainPrice = formatter?.string(from: product.bargainPrice as NSNumber) ?? "\(Int(product.bargainPrice))"
     
     if product.discountedPrice == 0 {
       self.price = nil
@@ -31,17 +33,15 @@ struct DetailViewModelItem {
       self.price = (formattedPrice ?? "\(Int(product.price))") + " \(self.currency)"
     }
     
-    self.bargainPrice = formatter?.string(from: product.bargainPrice as NSNumber) ?? "\(Int(product.bargainPrice))"
-    
-    let percentage = 0 // Int((product.discountedPrice / product.price * 100).rounded())
-    if percentage == 0 {
-      self.discountPercentage = nil
-    } else if percentage < 1 {
-      self.discountPercentage = "1%"
-    } else {
-      self.discountPercentage = "\(Int((product.discountedPrice / product.price * 100).rounded()))"
+    if product.price != 0 {
+      self.discountPercentage = self.calculateDiscountPercent(product: product)
     }
+  }
+  
+  private func calculateDiscountPercent(product: Product) -> String {
+    let percentage = Int((product.discountedPrice / product.price * 100).rounded())
     
-    self.stock = "\(product.stock) 개"
+    if percentage < 1 { return "1%" }
+    return "\(percentage)%"
   }
 }

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewModel/DetailViewModelItem.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewModel/DetailViewModelItem.swift
@@ -24,7 +24,9 @@ struct DetailViewModelItem {
     self.thumbnail = product.thumbnail
     self.currency = product.currency == "KRW" ? "원" : "달러"
     self.stock = "\(product.stock) 개"
-    self.discountPrice = formatter?.string(from: product.discountedPrice as NSNumber) ?? "\(Int(product.discountedPrice))"
+    self.discountPrice = formatter?.string(
+      from: product.discountedPrice as NSNumber
+    ) ?? "\(Int(product.discountedPrice))"
     
     if product.bargainPrice == 0 {
       self.price = nil

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewModel/DetailViewModelItem.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewModel/DetailViewModelItem.swift
@@ -14,7 +14,7 @@ struct DetailViewModelItem {
   let thumbnail: String
   let currency: String
   let price: String?
-  let bargainPrice: String
+  let discountPrice: String
   var discountPercentage: String?
   let stock: String
   
@@ -24,9 +24,9 @@ struct DetailViewModelItem {
     self.thumbnail = product.thumbnail
     self.currency = product.currency == "KRW" ? "원" : "달러"
     self.stock = "\(product.stock) 개"
-    self.bargainPrice = formatter?.string(from: product.bargainPrice as NSNumber) ?? "\(Int(product.bargainPrice))"
+    self.discountPrice = formatter?.string(from: product.discountedPrice as NSNumber) ?? "\(Int(product.discountedPrice))"
     
-    if product.discountedPrice == 0 {
+    if product.bargainPrice == 0 {
       self.price = nil
     } else {
       let formattedPrice = formatter?.string(from: product.price as NSNumber)
@@ -39,7 +39,7 @@ struct DetailViewModelItem {
   }
   
   private func calculateDiscountPercent(product: Product) -> String {
-    let percentage = Int((product.discountedPrice / product.price * 100).rounded())
+    let percentage = Int((product.bargainPrice / product.price * 100).rounded())
     
     if percentage < 1 { return "1%" }
     return "\(percentage)%"

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewModel/DetailViewModelable.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/Detail/ViewModel/DetailViewModelable.swift
@@ -18,9 +18,9 @@ protocol DetailViewModelOutput {
   var productImageCount: Observable<Int> { get }
 }
 
-protocol DetailViewModel: DetailViewModelInput, DetailViewModelOutput {}
+protocol DetailViewModelable: DetailViewModelInput, DetailViewModelOutput {}
 
-final class DetailViewModelImpl: DetailViewModel {
+final class DetailViewModel: DetailViewModelable {
   let useCase: ProductFetchUseCase
   let productId: Int
   

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/ProductCell/ProductCell.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/ProductCell/ProductCell.swift
@@ -45,7 +45,7 @@ final class ProductCell: UICollectionViewCell {
   
   private let discountPercentLabel: UILabel = {
     let label = UILabel()
-    label.font = ODS.Font.B_R13
+    label.font = ODS.Font.B_R15
     label.textColor = .systemRed
     return label
   }()
@@ -58,7 +58,7 @@ final class ProductCell: UICollectionViewCell {
     return label
   }()
   
-  private let bargainPriceLabel: UILabel = {
+  private let discountedPriceLabel: UILabel = {
     let label = UILabel()
     label.font = ODS.Font.B_R15
     
@@ -109,8 +109,8 @@ final class ProductCell: UICollectionViewCell {
     self.priceLabel.text = viewModel.price
     self.priceLabel.strike()
     
-    self.bargainPriceLabel.text = viewModel.bargainPrice
-    self.bargainPriceLabel.boldNumber()
+    self.discountedPriceLabel.text = viewModel.discountedPrice
+    self.discountedPriceLabel.boldNumber()
     
     self.stockTitleLabel.text = viewModel.stockTitle
     self.stockLabel.text = viewModel.stock
@@ -133,7 +133,7 @@ final class ProductCell: UICollectionViewCell {
     stockStackView.addArrangedSubview(stockLabel)
     
     bargainStackView.addArrangedSubview(discountPercentLabel)
-    bargainStackView.addArrangedSubview(bargainPriceLabel)
+    bargainStackView.addArrangedSubview(discountedPriceLabel)
   }
   
   private func setupCell() {

--- a/Projects/OmarketApp/Sources/Presentation/MainScene/ProductCell/ProductCellViewModel.swift
+++ b/Projects/OmarketApp/Sources/Presentation/MainScene/ProductCell/ProductCellViewModel.swift
@@ -16,7 +16,7 @@ protocol ProductCellViewModelOutput {
   var imageURL: String { get }
   var productName: String { get }
   var price: String { get }
-  var bargainPrice: String { get }
+  var discountedPrice: String { get }
   var dicountPercentage: String { get }
   var stockTitle: String { get }
   var stock: String { get }
@@ -48,14 +48,14 @@ final class ProductCellViewModel: ProductCellViewModelType {
     return formattedString(product.price)
   }
   
-  var bargainPrice: String {
-    return formattedString(product.bargainPrice)
+  var discountedPrice: String {
+    return formattedString(product.discountedPrice)
   }
   
   var dicountPercentage: String {
     if product.price == 0 { return "0%" }
     
-    let percentage = Int((product.discountedPrice / product.price * 100).rounded())
+    let percentage = Int((product.bargainPrice / product.price * 100).rounded())
     return percentage == 0 ? "1%" : "\(percentage)%"
   }
   
@@ -67,7 +67,7 @@ final class ProductCellViewModel: ProductCellViewModelType {
     return "\(product.stock) 개"
   }
   var isSale: Bool {
-    return product.discountedPrice != .zero
+    return product.bargainPrice != .zero
   }
   
   init(product: Product) {

--- a/Projects/OmarketApp/Tests/ViewModelTests/DetailViewModelTest.swift
+++ b/Projects/OmarketApp/Tests/ViewModelTests/DetailViewModelTest.swift
@@ -12,7 +12,7 @@ import XCTest
 import RxSwift
 
 final class DetailViewModelTest: XCTestCase {
-  private var sut: DetailViewModel!
+  private var sut: DetailViewModelable!
   private var productFetchuseCase: StubProductFetchUseCaseImpl!
   private var disposeBag: DisposeBag!
   private var dummyProduct: Product!
@@ -42,7 +42,7 @@ final class DetailViewModelTest: XCTestCase {
     )
     
     productFetchuseCase = StubProductFetchUseCaseImpl(products: [dummyProduct])
-    sut = DetailViewModelImpl(useCase: productFetchuseCase, productId: 1)
+    sut = DetailViewModel(useCase: productFetchuseCase, productId: 1)
     disposeBag = DisposeBag()
   }
   


### PR DESCRIPTION
### 배경

- 이슈: #43 

### 작업 내용
- DiscountPercent 계산 로직에서 에러가 발생하는 부분 수정
- 상세화면 더보기 버튼 추가
- Cell 로직 일부 수정

### 리뷰 노트
앱 실행 중 상세화면으로 넘어갈 때 DiscountPercent를 계산하는 부분에서 에러가 발생하여 로직을 수정하였습니다. 또한, Product 삭제 및 수정을 위한 더 보기 버튼을 NavigationItem에 추가하였으며, 추가로 Cell의 ViewModel의 일부 로직을 수정하였습니다.

### 스크린샷 및 영상

| 구현된 화면 |
|:---:|
| <img src="https://user-images.githubusercontent.com/91936941/195890802-48902818-e530-46f5-9013-0927d0daa187.gif" width="200"> |
