### PR TITLE
[D-3] 상품 삭제를 위한 API 및 기능 구현

### DIFF
--- a/Projects/OmarketApp/Sources/Data/Network/Infrastructure/EndpointAPI.swift
+++ b/Projects/OmarketApp/Sources/Data/Network/Infrastructure/EndpointAPI.swift
@@ -27,6 +27,7 @@ enum EndpointAPI {
   case productUpdate(Data?, Int)
   case searchProducts(String)
   case productURL(Data? ,Int)
+  case deleteProduct(String)
 
   var asEndpoint: Endpoint {
     switch self {
@@ -91,6 +92,16 @@ enum EndpointAPI {
         payload: payload
       )
       
+    case .deleteProduct(let url):
+      return Endpoint(
+        base: Base.baseURL,
+        path: url,
+        method: .delete,
+        headers: [
+          "Content-Type": "application/json",
+          "identifier": UserInformation.identifier
+        ]
+      )
     }
   }
 }

--- a/Projects/OmarketApp/Sources/Data/Network/Infrastructure/EndpointAPI.swift
+++ b/Projects/OmarketApp/Sources/Data/Network/Infrastructure/EndpointAPI.swift
@@ -26,6 +26,7 @@ enum EndpointAPI {
   case productCreation(Data, String)
   case productUpdate(Data?, Int)
   case searchProducts(String)
+  case productURL(Data? ,Int)
 
   var asEndpoint: Endpoint {
     switch self {
@@ -77,6 +78,19 @@ enum EndpointAPI {
         method: .get,
         queries: ["search_value": searchValue]
       )
+      
+    case .productURL(let payload, let id):
+      return Endpoint(
+        base: Base.baseURL,
+        path: "/api/products/\(id)/archived",
+        method: .post,
+        headers: [
+          "Content-Type": "application/json",
+          "identifier": UserInformation.identifier
+        ],
+        payload: payload
+      )
+      
     }
   }
 }

--- a/Projects/OmarketApp/Sources/Data/Network/Infrastructure/EndpointAPI.swift
+++ b/Projects/OmarketApp/Sources/Data/Network/Infrastructure/EndpointAPI.swift
@@ -26,7 +26,7 @@ enum EndpointAPI {
   case productCreation(Data, String)
   case productUpdate(Data?, Int)
   case searchProducts(String)
-  case productURL(Data? ,Int)
+  case productURL(Data?, Int)
   case deleteProduct(String)
 
   var asEndpoint: Endpoint {

--- a/Projects/OmarketApp/Sources/Data/Repository/ProductRepositoryImpl.swift
+++ b/Projects/OmarketApp/Sources/Data/Repository/ProductRepositoryImpl.swift
@@ -43,7 +43,7 @@ final class ProductRepositoryImpl: ProductRepository {
   
   func productURL(endpoint: Endpoint) -> Observable<String> {
     return networkService.request(endpoint: endpoint)
-      .map { String(decoding: $0, as: UTF8.self) }
+      .map { String(data: $0, encoding: .utf8) ?? "" }
   }
   
   func deleteProduct(endpoint: Endpoint) -> Observable<Void> {

--- a/Projects/OmarketApp/Sources/Data/Repository/ProductRepositoryImpl.swift
+++ b/Projects/OmarketApp/Sources/Data/Repository/ProductRepositoryImpl.swift
@@ -40,4 +40,14 @@ final class ProductRepositoryImpl: ProductRepository {
     return networkService.request(endpoint: endpoint)
       .map { _ in }
   }
+  
+  func productURL(endpoint: Endpoint) -> Observable<String> {
+    return networkService.request(endpoint: endpoint)
+      .map { String(decoding: $0, as: UTF8.self) }
+  }
+  
+  func deleteProduct(endpoint: Endpoint) -> Observable<Void> {
+    return networkService.request(endpoint: endpoint)
+      .map { _ in }
+  }
 }

--- a/Projects/OmarketApp/Sources/Domain/Interface/Repository/ProductRepository.swift
+++ b/Projects/OmarketApp/Sources/Domain/Interface/Repository/ProductRepository.swift
@@ -15,4 +15,6 @@ protocol ProductRepository {
   func fetchProduct(endpoint: Endpoint) -> Observable<Product>
   func createProduct(endpoint: Endpoint) -> Observable<Void>
   func updateProduct(endpoint: Endpoint) -> Observable<Void>
+  func productURL(endpoint: Endpoint) -> Observable<String>
+  func deleteProduct(endpoint: Endpoint) -> Observable<Void>
 }

--- a/Projects/OmarketApp/Sources/Domain/UseCase/ProductFetchUseCase.swift
+++ b/Projects/OmarketApp/Sources/Domain/UseCase/ProductFetchUseCase.swift
@@ -21,6 +21,8 @@ protocol ProductFetchUseCase {
   func createProduct(product: Product, images: [Data]) -> Observable<Void>
   func updateProduct(product: Product) -> Observable<Void>
   func searchProducts(searchValue: String) -> Observable<[Product]>
+  func productURL(id: Int, password: String) -> Observable<String>
+  func deleteProduct(url: String) -> Observable<Void>
 }
 
 final class ProductFetchUseCaseImpl: ProductFetchUseCase {
@@ -62,6 +64,17 @@ final class ProductFetchUseCaseImpl: ProductFetchUseCase {
   func searchProducts(searchValue: String) -> Observable<[Product]> {
     let endpoint = EndpointAPI.searchProducts(searchValue).asEndpoint
     return repository.fetchAllProduct(endpoint: endpoint)
+  }
+  
+  func productURL(id: Int, password: String) -> Observable<String> {
+    let payload = "{\"secret\": \"\(password)\"}".data(using: .utf8)
+    let endpoint = EndpointAPI.productURL(payload, id).asEndpoint
+    return repository.productURL(endpoint: endpoint)
+  }
+  
+  func deleteProduct(url: String) -> Observable<Void> {
+    let endpoint = EndpointAPI.deleteProduct(url).asEndpoint
+    return repository.deleteProduct(endpoint: endpoint)
   }
 }
 

--- a/Projects/OmarketApp/Sources/Presentation/Detail/ViewController/DetailViewController.swift
+++ b/Projects/OmarketApp/Sources/Presentation/Detail/ViewController/DetailViewController.swift
@@ -87,7 +87,7 @@ extension DetailViewController {
           self?.coordinator?.showEditingView(product: product)
         }
         let deleteAction = UIAlertAction(title: "삭제", style: .destructive) {_ in
-          // action
+          self?.showDeleteAlert(viewModel: viewModel)
         }
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         
@@ -134,5 +134,35 @@ extension DetailViewController {
         self?.mainView.pageControl.numberOfPages = $0
       }
       .disposed(by: disposeBag)
+  }
+}
+
+extension DetailViewController {
+  private func showDeleteAlert(viewModel: DetailViewModelable) {
+    let alert = UIAlertController(
+      title: nil,
+      message: "게시글을 정말 삭제하시겠어요?",
+      preferredStyle: .alert
+    )
+    let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+      viewModel.deleteButtonDidTap {
+        DispatchQueue.main.async {
+          NotificationCenter.default.post(name: .productsDidRenew, object: nil)
+          self?.navigationController?.popViewController(animated: true)
+        }
+      } errorHandler: { error in
+        DispatchQueue.main.async {
+          let alert = UIAlertController.makeAlert(message: error.localizedDescription)
+          self?.present(alert, animated: true)
+        }
+      }
+    }
+    
+    let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+    
+    [deleteAction, cancelAction].forEach { action in
+      alert.addAction(action)
+    }
+    present(alert, animated: true)
   }
 }

--- a/Projects/OmarketApp/Sources/Presentation/Detail/ViewController/DetailViewController.swift
+++ b/Projects/OmarketApp/Sources/Presentation/Detail/ViewController/DetailViewController.swift
@@ -172,13 +172,13 @@ extension DetailViewController {
         message: "게시글을 정말 삭제하시겠어요?",
         preferredStyle: .alert
       )
-      ["삭제", "취소"].forEach { title in
-        let action = UIAlertAction(
-          title: title,
-          style: title == "삭제" ? .destructive : .cancel
-        ) { _ in
-          single(.success(title))
-        }
+      let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { _ in
+        single(.success("삭제"))
+      }
+      let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
+        single(.success("취소"))
+      }
+      [deleteAction, cancelAction].forEach { action in
         alert.addAction(action)
       }
       self?.present(alert, animated: true)

--- a/Projects/OmarketApp/Sources/Presentation/Detail/ViewController/DetailViewController.swift
+++ b/Projects/OmarketApp/Sources/Presentation/Detail/ViewController/DetailViewController.swift
@@ -145,17 +145,19 @@ extension DetailViewController {
       preferredStyle: .alert
     )
     let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
-      viewModel.deleteButtonDidTap {
-        DispatchQueue.main.async {
-          NotificationCenter.default.post(name: .productsDidRenew, object: nil)
-          self?.navigationController?.popViewController(animated: true)
-        }
-      } errorHandler: { error in
-        DispatchQueue.main.async {
-          let alert = UIAlertController.makeAlert(message: error.localizedDescription)
-          self?.present(alert, animated: true)
-        }
-      }
+      guard let self = self else { return }
+      viewModel.deleteButtonDidTap()
+        .subscribe { _ in
+          DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .productsDidRenew, object: nil)
+            self.navigationController?.popViewController(animated: true)
+          }
+        } onError: { error in
+          DispatchQueue.main.async {
+            let alert = UIAlertController.makeAlert(message: error.localizedDescription)
+            self.present(alert, animated: true)
+          }
+        }.disposed(by: self.disposeBag)
     }
     
     let cancelAction = UIAlertAction(title: "취소", style: .cancel)

--- a/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
+++ b/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
@@ -51,7 +51,7 @@ final class DetailViewModel: DetailViewModelable {
   ) {
     useCase.productURL(id: productId, password: UserInformation.password)
       .withUnretained(self)
-      .subscribe (
+      .subscribe(
         onNext: { owner, url in
           owner.useCase.deleteProduct(url: url)
             .subscribe(

--- a/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
+++ b/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
@@ -12,7 +12,7 @@ import RxSwift
 
 protocol DetailViewModelInput {
   func fetchProductDetail()
-  func deleteButtonDidTap(completion: @escaping (() -> Void), errorHandler: @escaping ((Error) -> Void))
+  func deleteButtonDidTap() -> Observable<Void>
 }
 
 protocol DetailViewModelOutput {
@@ -45,21 +45,10 @@ final class DetailViewModel: DetailViewModelable {
     self.productId = productId
   }
   
-  func deleteButtonDidTap(
-    completion: @escaping (() -> Void),
-    errorHandler: @escaping ((Error) -> Void)
-  ) {
-    useCase.productURL(id: productId, password: UserInformation.password)
+  func deleteButtonDidTap() -> Observable<Void> {
+    return useCase.productURL(id: productId, password: UserInformation.password)
       .withUnretained(self)
-      .subscribe(
-        onNext: { owner, url in
-          owner.useCase.deleteProduct(url: url)
-            .subscribe(
-              onNext: completion,
-              onError: errorHandler
-            ).disposed(by: owner.disposeBag)
-        }, onError: errorHandler
-      ).disposed(by: disposeBag)
+      .flatMap { owner, url in owner.useCase.deleteProduct(url: url) }
   }
   
   func fetchProductDetail() {

--- a/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
+++ b/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
@@ -51,16 +51,15 @@ final class DetailViewModel: DetailViewModelable {
   ) {
     useCase.productURL(id: productId, password: UserInformation.password)
       .withUnretained(self)
-      .subscribe { owner, url in
-        owner.useCase.deleteProduct(url: url)
-          .subscribe { _ in
-            completion()
-          } onError: { error in
-            errorHandler(error)
-          }.disposed(by: owner.disposeBag)
-      } onError: { error in
-        errorHandler(error)
-      }.disposed(by: disposeBag)
+      .subscribe (
+        onNext: { owner, url in
+          owner.useCase.deleteProduct(url: url)
+            .subscribe(
+              onNext: completion,
+              onError: errorHandler
+            ).disposed(by: owner.disposeBag)
+        }, onError: errorHandler
+      ).disposed(by: disposeBag)
   }
   
   func fetchProductDetail() {

--- a/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
+++ b/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 protocol DetailViewModelInput {
   func fetchProductDetail()
+  func deleteButtonDidTap(completion: @escaping (() -> Void), errorHandler: @escaping ((Error) -> Void))
 }
 
 protocol DetailViewModelOutput {
@@ -42,6 +43,24 @@ final class DetailViewModel: DetailViewModelable {
   init(useCase: ProductFetchUseCase, productId: Int) {
     self.useCase = useCase
     self.productId = productId
+  }
+  
+  func deleteButtonDidTap(
+    completion: @escaping (() -> Void),
+    errorHandler: @escaping ((Error) -> Void)
+  ) {
+    useCase.productURL(id: productId, password: UserInformation.password)
+      .withUnretained(self)
+      .subscribe { owner, url in
+        owner.useCase.deleteProduct(url: url)
+          .subscribe { _ in
+            completion()
+          } onError: { error in
+            errorHandler(error)
+          }.disposed(by: owner.disposeBag)
+      } onError: { error in
+        errorHandler(error)
+      }.disposed(by: disposeBag)
   }
   
   func fetchProductDetail() {

--- a/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
+++ b/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
@@ -24,8 +24,8 @@ protocol DetailViewModelOutput {
   var productImageURL: Observable<[String]> { get }
   var productImageCount: Observable<Int> { get }
   var product: Product? { get }
-  var editAction: PublishRelay<Void> { get }
-  var deleteAction: PublishRelay<Void> { get }
+  var editAction: Observable<Void> { get }
+  var deleteAction: Observable<Void> { get }
 }
 
 protocol DetailViewModelable: DetailViewModelInput, DetailViewModelOutput {}
@@ -36,8 +36,8 @@ final class DetailViewModel: DetailViewModelable {
   private(set) var product: Product?
   
   private let productBuffer = ReplaySubject<Product>.create(bufferSize: 1)
-  let editAction = PublishRelay<Void>()
-  let deleteAction = PublishRelay<Void>()
+  private let editActionObserver = PublishRelay<Void>()
+  private let deleteActionObserver = PublishRelay<Void>()
   private let deletionObserver = PublishRelay<Void>()
   private let disposeBag = DisposeBag()
   
@@ -76,9 +76,9 @@ final class DetailViewModel: DetailViewModelable {
   func selectEditAlertAction(_ actionTitle: String) {
     switch actionTitle {
     case "수정":
-      editAction.accept(())
+      editActionObserver.accept(())
     case "삭제":
-      deleteAction.accept(())
+      deleteActionObserver.accept(())
     default:
       break
     }
@@ -117,5 +117,13 @@ final class DetailViewModel: DetailViewModelable {
   var productImageCount: Observable<Int> {
     return productImageURL
       .map { $0.count }
+  }
+  
+  var editAction: Observable<Void> {
+    return editActionObserver.asObservable()
+  }
+  
+  var deleteAction: Observable<Void> {
+    return deleteActionObserver.asObservable()
   }
 }

--- a/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
+++ b/Projects/OmarketApp/Sources/Presentation/Detail/ViewModel/DetailViewModel.swift
@@ -45,7 +45,7 @@ final class DetailViewModel: DetailViewModelable {
   }
   
   func fetchProductDetail() {
-    self.useCase
+    useCase
       .fetchOne(id: productId)
       .subscribe(onNext: { [weak self] in
         self?.product = $0

--- a/Projects/OmarketApp/Tests/RepositoryTests/ProductRepositoryTests.swift
+++ b/Projects/OmarketApp/Tests/RepositoryTests/ProductRepositoryTests.swift
@@ -229,4 +229,82 @@ final class ProductRepositoryTests: XCTestCase {
       .disposed(by: disposeBag)
     wait(for: [expectation], timeout: 5.0)
   }
+  
+  func test_productURL을_호출했을때_성공한_경우_에러가_방출되지_않아야한다() {
+    // given
+    let expectation = XCTestExpectation()
+    let endpoint = EndpointAPI.productURL(nil, 1).asEndpoint
+    networkService = StubNetworkServiceImpl(data: try! JSONEncoder().encode("url"), isSuccess: true)
+    sut = ProductRepositoryImpl(networkService: networkService)
+    
+    // when
+    sut.productURL(endpoint: endpoint)
+      .subscribe(onNext: {
+        // then
+        XCTAssertEqual($0, "\"url\"")
+        expectation.fulfill()
+      }, onError: { error in
+        XCTFail()
+      })
+      .disposed(by: disposeBag)
+    wait(for: [expectation], timeout: 5.0)
+  }
+  
+  func test_productURL을_호출했을때_실패한_경우_BadRequest가_나와야한다() {
+    // given
+    let expectation = XCTestExpectation()
+    let endpoint = EndpointAPI.productURL(nil, 1).asEndpoint
+    networkService = StubNetworkServiceImpl(data: Data(), isSuccess: false)
+    sut = ProductRepositoryImpl(networkService: networkService)
+    
+    // when
+    sut.productURL(endpoint: endpoint)
+      .subscribe(onNext: { _ in
+        XCTFail()
+      }, onError: { error in
+        // then
+        XCTAssertEqual(error as! NetworkServiceError, NetworkServiceError.badRequest)
+        expectation.fulfill()
+      })
+      .disposed(by: disposeBag)
+    wait(for: [expectation], timeout: 5.0)
+  }
+  
+  func test_deleteProduct을_호출했을때_성공한_경우_에러가_방출되지_않아야한다() {
+    // given
+    let expectation = XCTestExpectation()
+    let endpoint = EndpointAPI.deleteProduct("url").asEndpoint
+    sut = ProductRepositoryImpl(networkService: networkService)
+    
+    // when
+    sut.deleteProduct(endpoint: endpoint)
+      .subscribe(onNext: {
+        // then
+        expectation.fulfill()
+      }, onError: { error in
+        XCTFail()
+      })
+      .disposed(by: disposeBag)
+    wait(for: [expectation], timeout: 5.0)
+  }
+  
+  func test_deleteProduct을_호출했을때_실패한_경우_BadRequest가_나와야한다() {
+    // given
+    let expectation = XCTestExpectation()
+    let endpoint = EndpointAPI.deleteProduct("url").asEndpoint
+    networkService = StubNetworkServiceImpl(data: Data(), isSuccess: false)
+    sut = ProductRepositoryImpl(networkService: networkService)
+    
+    // when
+    sut.deleteProduct(endpoint: endpoint)
+      .subscribe(onNext: {
+        XCTFail()
+      }, onError: { error in
+        // then
+        XCTAssertEqual(error as! NetworkServiceError, NetworkServiceError.badRequest)
+        expectation.fulfill()
+      })
+      .disposed(by: disposeBag)
+    wait(for: [expectation], timeout: 5.0)
+  }
 }

--- a/Projects/OmarketApp/Tests/TestDouble/Mock/MockProductRepositoryImpl.swift
+++ b/Projects/OmarketApp/Tests/TestDouble/Mock/MockProductRepositoryImpl.swift
@@ -16,6 +16,8 @@ final class MockProductRepositoryImpl: ProductRepository {
   var fetchProductCallCount: Int = 0
   var createProductCallCount: Int = 0
   var updateProductCallCount: Int = 0
+  var productURLCallCount: Int = 0
+  var deleteProductCallCount: Int = 0
 
   func fetchAllProduct(endpoint: Endpoint) -> Observable<[Product]> {
     fetchAllProductCallCount += 1
@@ -34,6 +36,16 @@ final class MockProductRepositoryImpl: ProductRepository {
   
   func updateProduct(endpoint: Endpoint) -> Observable<Void> {
     updateProductCallCount += 1
+    return .empty()
+  }
+  
+  func productURL(endpoint: OmarketApp.Endpoint) -> Observable<String> {
+    productURLCallCount += 1
+    return .empty()
+  }
+  
+  func deleteProduct(endpoint: OmarketApp.Endpoint) -> Observable<Void> {
+    deleteProductCallCount += 1
     return .empty()
   }
 }

--- a/Projects/OmarketApp/Tests/TestDouble/Stub/StubProductFetchUseCaseImpl.swift
+++ b/Projects/OmarketApp/Tests/TestDouble/Stub/StubProductFetchUseCaseImpl.swift
@@ -36,4 +36,16 @@ final class StubProductFetchUseCaseImpl: ProductFetchUseCase {
     products.append(product)
     return .just(Void())
   }
+  
+  func searchProducts(searchValue: String) -> Observable<[Product]> {
+    return .just(products)
+  }
+  
+  func productURL(id: Int, password: String) -> Observable<String> {
+    return .just("url")
+  }
+  
+  func deleteProduct(url: String) -> Observable<Void> {
+    return .just(Void())
+  }
 }

--- a/Projects/OmarketApp/Tests/UseCaseTests/ProductFetchUseCaseTests.swift
+++ b/Projects/OmarketApp/Tests/UseCaseTests/ProductFetchUseCaseTests.swift
@@ -82,4 +82,20 @@ final class ProductFetchUseCaseTests: XCTestCase {
     // then
     XCTAssertEqual(output, 1)
   }
+  
+  func test_productURL호출되었을때_Repository의_productURL_메서드가_호출되어야한다() {
+    // given when
+    _ = sut.productURL(id: 1, password: "password")
+
+    // then
+    XCTAssertEqual(repository.productURLCallCount, 1)
+  }
+  
+  func test_deleteProduct호출되었을때_Repository의_deleteProduct_메서드가_호출되어야한다() {
+    // given when
+    _ = sut.deleteProduct(url: "url")
+
+    // then
+    XCTAssertEqual(repository.deleteProductCallCount, 1)
+  }
 }

--- a/Projects/OmarketApp/Tests/ViewModelTests/CreateViewModelTest.swift
+++ b/Projects/OmarketApp/Tests/ViewModelTests/CreateViewModelTest.swift
@@ -39,7 +39,7 @@ final class CreateViewModelTest: XCTestCase {
     )
     
     productFetchuseCase = StubProductFetchUseCaseImpl(products: [dummyProduct])
-    sut = CreationViewModel(useCase: productFetchuseCase)
+    sut = CreationViewModel(useCase: productFetchuseCase, imageCountMax: 5, imageCountMin: 1)
     disposeBag = DisposeBag()
   }
   
@@ -55,7 +55,7 @@ final class CreateViewModelTest: XCTestCase {
     // given
     let imageDatas = [dummyImageData!]
     // when
-    sut.selectedImageData(imageDatas)
+    sut.selectedImageData(imageDatas.first!)
     sut.numberOfImagesSelected
       .subscribe {
         // then
@@ -67,16 +67,16 @@ final class CreateViewModelTest: XCTestCase {
     // given
     let imageDatas = [dummyImageData!]
     // when
-    sut.selectedImageData(imageDatas)
+    sut.selectedImageData(imageDatas.first!)
     // then
-    XCTAssertEqual(sut.selectionLimit, sut.imageCountLimit - imageDatas.count)
+    XCTAssertEqual(sut.selectionLimit, sut.imageCountMax - imageDatas.count)
   }
   
   func test_removeImageData를_통해_imageData를_삭제했을_때_numberOfImagesSelected의_값이_하나_감소해야한다() {
     // given
     let imageDatas = [dummyImageData!]
     // when
-    sut.selectedImageData(imageDatas)
+    sut.selectedImageData(imageDatas.first!)
     sut.removeImageData(id: dummyImageData.id)
     sut.numberOfImagesSelected
       .subscribe {
@@ -89,7 +89,7 @@ final class CreateViewModelTest: XCTestCase {
     // given
     let imageDatas = [dummyImageData!]
     // when
-    sut.selectedImageData(imageDatas)
+    sut.selectedImageData(imageDatas.first!)
     sut.doneButtonDidTap(product: dummyProduct)
       .subscribe {
         // then


### PR DESCRIPTION
### 배경

- 이슈: #70 

### 작업 내용
- 삭제를 위한 product URL 및 delete API 구현
- useCase, Repository, VM, VC 삭제에 필요한 메서드 구현
- Alert을 통한 삭제 의사 확인 

### 테스트 방법
Test 진행 예정

### 리뷰 노트
따로 비밀번호를 사용자가 입력하지 않고, 중첩으로 네트워크 통신하여 Alert 삭제 버튼을 클릭시 바로 삭제가 되도록 구현하였습니다.

### 스크린샷 및 영상

| 구현 화면 |
|:---:|
|<img src="https://user-images.githubusercontent.com/91936941/203058274-7651c888-cf48-467c-b90a-398399a9ce9e.gif" width="200">|
